### PR TITLE
Support commit listing for single file within repository

### DIFF
--- a/Controllers/CommitsController.cs
+++ b/Controllers/CommitsController.cs
@@ -6,6 +6,8 @@ namespace GitHubSharp.Controllers
 {
     public class CommitsController : Controller
     {
+        public string FilePath { get; set; }
+
         public RepositoryController RepositoryController { get; private set; }
 
         public CommitController this[string key]
@@ -29,7 +31,7 @@ namespace GitHubSharp.Controllers
 
         public override string Uri
         {
-            get { return RepositoryController.Uri + "/commits"; }
+            get { return RepositoryController.Uri + "/commits" + (string.IsNullOrEmpty(this.FilePath) ? string.Empty : "?path=" + this.FilePath); }
         }
     }
 


### PR DESCRIPTION
In case FilePath property is set, filtered list of commits will be returned.

e.g. below REST call lists commits affecting README.md only:
https://api.github.com/repos/akos-sereg/JInvoc/commits?path=README.md
